### PR TITLE
Fix infinitely running scheduled task

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -29,7 +29,7 @@ variables:
 #       recursive: true
 #       submodule_update_remote: true
 
-pipeline:
+steps:
   prepare_repo:
     image: alpine:3
     commands:

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -17,7 +17,7 @@ pub async fn list_comment_reports(
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
   let community_id = data.community_id;
-  let unresolved_only = data.unresolved_only;
+  let unresolved_only = data.unresolved_only.unwrap_or_default();
 
   let page = data.page;
   let limit = data.limit;

--- a/crates/api/src/community/block.rs
+++ b/crates/api/src/community/block.rs
@@ -52,7 +52,7 @@ pub async fn block_community(
   }
 
   let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), None).await?;
+    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
 
   ActivityChannel::submit_activity(
     SendActivityData::FollowCommunity(

--- a/crates/api/src/community/follow.rs
+++ b/crates/api/src/community/follow.rs
@@ -61,7 +61,7 @@ pub async fn follow_community(
   let community_id = data.community_id;
   let person_id = local_user_view.person.id;
   let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), None).await?;
+    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
   let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
 
   Ok(Json(CommunityResponse {

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -84,7 +84,7 @@ impl Perform for TransferCommunity {
     let community_id = data.community_id;
     let person_id = local_user_view.person.id;
     let community_view =
-      CommunityView::read(&mut context.pool(), community_id, Some(person_id), None)
+      CommunityView::read(&mut context.pool(), community_id, Some(person_id), false)
         .await
         .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
 

--- a/crates/api/src/local_user/notifications/list_mentions.rs
+++ b/crates/api/src/local_user/notifications/list_mentions.rs
@@ -23,9 +23,9 @@ impl Perform for GetPersonMentions {
     let sort = data.sort;
     let page = data.page;
     let limit = data.limit;
-    let unread_only = data.unread_only;
+    let unread_only = data.unread_only.unwrap_or_default();
     let person_id = Some(local_user_view.person.id);
-    let show_bot_accounts = Some(local_user_view.local_user.show_bot_accounts);
+    let show_bot_accounts = local_user_view.local_user.show_bot_accounts;
 
     let mentions = PersonMentionQuery {
       recipient_id: person_id,

--- a/crates/api/src/local_user/notifications/list_replies.rs
+++ b/crates/api/src/local_user/notifications/list_replies.rs
@@ -20,9 +20,9 @@ impl Perform for GetReplies {
     let sort = data.sort;
     let page = data.page;
     let limit = data.limit;
-    let unread_only = data.unread_only;
+    let unread_only = data.unread_only.unwrap_or_default();
     let person_id = Some(local_user_view.person.id);
-    let show_bot_accounts = Some(local_user_view.local_user.show_bot_accounts);
+    let show_bot_accounts = local_user_view.local_user.show_bot_accounts;
 
     let replies = CommentReplyQuery {
       recipient_id: person_id,

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -28,7 +28,7 @@ impl Perform for MarkPostAsRead {
     }
 
     // Fetch it
-    let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), None).await?;
+    let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), false).await?;
 
     Ok(Self::Response { post_view })
   }

--- a/crates/api/src/post/save.rs
+++ b/crates/api/src/post/save.rs
@@ -38,7 +38,7 @@ impl Perform for SavePost {
 
     let post_id = data.post_id;
     let person_id = local_user_view.person.id;
-    let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), None).await?;
+    let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), false).await?;
 
     // Mark the post as read
     mark_post_as_read(person_id, post_id, &mut context.pool()).await?;

--- a/crates/api/src/post_report/create.rs
+++ b/crates/api/src/post_report/create.rs
@@ -36,7 +36,7 @@ pub async fn create_post_report(
 
   let person_id = local_user_view.person.id;
   let post_id = data.post_id;
-  let post_view = PostView::read(&mut context.pool(), post_id, None, None).await?;
+  let post_view = PostView::read(&mut context.pool(), post_id, None, false).await?;
 
   check_community_ban(person_id, post_view.community.id, &mut context.pool()).await?;
 

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -23,7 +23,7 @@ impl Perform for ListPostReports {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     let community_id = data.community_id;
-    let unresolved_only = data.unresolved_only;
+    let unresolved_only = data.unresolved_only.unwrap_or_default();
 
     let page = data.page;
     let limit = data.limit;

--- a/crates/api/src/private_message_report/list.rs
+++ b/crates/api/src/private_message_report/list.rs
@@ -18,7 +18,7 @@ impl Perform for ListPrivateMessageReports {
 
     is_admin(&local_user_view)?;
 
-    let unresolved_only = self.unresolved_only;
+    let unresolved_only = self.unresolved_only.unwrap_or_default();
     let page = self.page;
     let limit = self.limit;
     let private_message_reports = PrivateMessageReportQuery {

--- a/crates/api/src/site/registration_applications/list.rs
+++ b/crates/api/src/site/registration_applications/list.rs
@@ -22,8 +22,8 @@ impl Perform for ListRegistrationApplications {
     // Make sure user is an admin
     is_admin(&local_user_view)?;
 
-    let unread_only = data.unread_only;
-    let verified_email_only = Some(local_site.require_email_verification);
+    let unread_only = data.unread_only.unwrap_or_default();
+    let verified_email_only = local_site.require_email_verification;
 
     let page = data.page;
     let limit = data.limit;

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -50,7 +50,7 @@ pub async fn build_community_response(
     &mut context.pool(),
     community_id,
     Some(person_id),
-    Some(is_mod_or_admin),
+    is_mod_or_admin,
   )
   .await?;
   let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
@@ -74,7 +74,7 @@ pub async fn build_post_response(
     &mut context.pool(),
     post_id,
     Some(person_id),
-    Some(is_mod_or_admin),
+    is_mod_or_admin,
   )
   .await?;
   Ok(Json(PostResponse { post_view }))

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -15,13 +15,16 @@ pub async fn list_communities(
 ) -> Result<Json<ListCommunitiesResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
   let local_site = LocalSite::read(&mut context.pool()).await?;
-  let is_admin = local_user_view.as_ref().map(|luv| is_admin(luv).is_ok());
+  let is_admin = local_user_view
+    .as_ref()
+    .map(|luv| is_admin(luv).is_ok())
+    .unwrap_or_default();
 
   check_private_instance(&local_user_view, &local_site)?;
 
   let sort = data.sort;
   let listing_type = data.type_;
-  let show_nsfw = data.show_nsfw;
+  let show_nsfw = data.show_nsfw.unwrap_or_default();
   let page = data.page;
   let limit = data.limit;
   let local_user = local_user_view.map(|l| l.local_user);

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -52,14 +52,9 @@ pub async fn get_post(
   .await
   .is_ok();
 
-  let post_view = PostView::read(
-    &mut context.pool(),
-    post_id,
-    person_id,
-    Some(is_mod_or_admin),
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntFindPost)?;
+  let post_view = PostView::read(&mut context.pool(), post_id, person_id, is_mod_or_admin)
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntFindPost)?;
 
   // Mark the post as read
   let post_id = post_view.post.id;
@@ -72,7 +67,7 @@ pub async fn get_post(
     &mut context.pool(),
     community_id,
     person_id,
-    Some(is_mod_or_admin),
+    is_mod_or_admin,
   )
   .await
   .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -17,7 +17,7 @@ pub async fn get_private_message(
 
   let page = data.page;
   let limit = data.limit;
-  let unread_only = data.unread_only;
+  let unread_only = data.unread_only.unwrap_or_default();
   let creator_id = data.creator_id;
   let mut messages = PrivateMessageQuery {
     page,

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -97,7 +97,9 @@ pub(crate) async fn verify_person_in_community(
 ) -> Result<(), LemmyError> {
   let person = person_id.dereference(context).await?;
   if person.banned {
-    return Err(LemmyErrorType::PersonIsBannedFromSite)?;
+    return Err(LemmyErrorType::PersonIsBannedFromSite(
+      person.actor_id.to_string(),
+    ))?;
   }
   let person_id = person.id;
   let community_id = community.id;

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -34,11 +34,11 @@ pub async fn list_comments(
   };
   let sort = data.sort;
   let max_depth = data.max_depth;
-  let saved_only = data.saved_only;
+  let saved_only = data.saved_only.unwrap_or_default();
 
-  let liked_only = data.liked_only;
-  let disliked_only = data.disliked_only;
-  if liked_only.unwrap_or_default() && disliked_only.unwrap_or_default() {
+  let liked_only = data.liked_only.unwrap_or_default();
+  let disliked_only = data.disliked_only.unwrap_or_default();
+  if liked_only && disliked_only {
     return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
   }
 

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -34,15 +34,15 @@ pub async fn list_posts(
   } else {
     data.community_id
   };
-  let saved_only = data.saved_only;
+  let saved_only = data.saved_only.unwrap_or_default();
 
-  let liked_only = data.liked_only;
-  let disliked_only = data.disliked_only;
-  if liked_only.unwrap_or_default() && disliked_only.unwrap_or_default() {
+  let liked_only = data.liked_only.unwrap_or_default();
+  let disliked_only = data.disliked_only.unwrap_or_default();
+  if liked_only && disliked_only {
     return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
   }
 
-  let moderator_view = data.moderator_view;
+  let moderator_view = data.moderator_view.unwrap_or_default();
 
   let listing_type = Some(listing_type_with_default(
     data.type_,

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -54,7 +54,7 @@ pub async fn get_community(
     &mut context.pool(),
     community_id,
     person_id,
-    Some(is_mod_or_admin),
+    is_mod_or_admin,
   )
   .await
   .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -50,11 +50,11 @@ pub async fn read_person(
   let sort = data.sort;
   let page = data.page;
   let limit = data.limit;
-  let saved_only = data.saved_only;
+  let saved_only = data.saved_only.unwrap_or_default();
   let community_id = data.community_id;
   // If its saved only, you don't care what creator it was
   // Or, if its not saved, then you only want it for that specific creator
-  let creator_id = if !saved_only.unwrap_or(false) {
+  let creator_id = if !saved_only {
     Some(person_details_id)
   } else {
     None

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -58,11 +58,11 @@ async fn convert_response(
     }
     Community(c) => {
       removed_or_deleted = c.deleted || c.removed;
-      res.community = Some(CommunityView::read(pool, c.id, user_id, None).await?)
+      res.community = Some(CommunityView::read(pool, c.id, user_id, false).await?)
     }
     Post(p) => {
       removed_or_deleted = p.deleted || p.removed;
-      res.post = Some(PostView::read(pool, p.id, user_id, None).await?)
+      res.post = Some(PostView::read(pool, p.id, user_id, false).await?)
     }
     Comment(c) => {
       removed_or_deleted = c.deleted || c.removed;

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -25,7 +25,10 @@ pub async fn search(
 
   check_private_instance(&local_user_view, &local_site)?;
 
-  let is_admin = local_user_view.as_ref().map(|luv| is_admin(luv).is_ok());
+  let is_admin = local_user_view
+    .as_ref()
+    .map(|luv| is_admin(luv).is_ok())
+    .unwrap_or_default();
 
   let mut posts = Vec::new();
   let mut comments = Vec::new();

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -107,7 +107,9 @@ impl Object for ApubPrivateMessage {
     check_apub_id_valid_with_strictness(note.id.inner(), false, context).await?;
     let person = note.attributed_to.dereference(context).await?;
     if person.banned {
-      return Err(LemmyErrorType::PersonIsBannedFromSite)?;
+      return Err(LemmyErrorType::PersonIsBannedFromSite(
+        person.actor_id.to_string(),
+      ))?;
     }
     Ok(())
   }

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -113,7 +113,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(post::community_id.eq(community_id));
     }
 
-    if options.unresolved_only.unwrap_or(false) {
+    if options.unresolved_only {
       query = query.filter(comment_report::resolved.eq(false));
     }
 
@@ -206,7 +206,7 @@ pub struct CommentReportQuery {
   pub community_id: Option<CommunityId>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub unresolved_only: Option<bool>,
+  pub unresolved_only: bool,
 }
 
 impl CommentReportQuery {
@@ -569,7 +569,7 @@ mod tests {
     // Do a batch read of timmys reports
     // It should only show saras, which is unresolved
     let reports_after_resolve = CommentReportQuery {
-      unresolved_only: (Some(true)),
+      unresolved_only: (true),
       ..Default::default()
     }
     .list(pool, &inserted_timmy)

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -189,13 +189,13 @@ fn queries<'a>() -> Queries<
       }
     }
 
-    if options.saved_only.unwrap_or(false) {
+    if options.saved_only {
       query = query.filter(comment_saved::comment_id.is_not_null());
     }
 
-    if options.liked_only.unwrap_or_default() {
+    if options.liked_only {
       query = query.filter(comment_like::score.eq(1));
-    } else if options.disliked_only.unwrap_or_default() {
+    } else if options.disliked_only {
       query = query.filter(comment_like::score.eq(-1));
     }
 
@@ -312,9 +312,9 @@ pub struct CommentQuery<'a> {
   pub creator_id: Option<PersonId>,
   pub local_user: Option<&'a LocalUserView>,
   pub search_term: Option<String>,
-  pub saved_only: Option<bool>,
-  pub liked_only: Option<bool>,
-  pub disliked_only: Option<bool>,
+  pub saved_only: bool,
+  pub liked_only: bool,
+  pub disliked_only: bool,
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -615,7 +615,7 @@ mod tests {
 
     let read_liked_comment_views = CommentQuery {
       local_user: (Some(&data.local_user_view)),
-      liked_only: (Some(true)),
+      liked_only: (true),
       ..Default::default()
     }
     .list(pool)
@@ -631,7 +631,7 @@ mod tests {
 
     let read_disliked_comment_views: Vec<CommentView> = CommentQuery {
       local_user: (Some(&data.local_user_view)),
-      disliked_only: (Some(true)),
+      disliked_only: (true),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -98,7 +98,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(post::community_id.eq(community_id));
     }
 
-    if options.unresolved_only.unwrap_or(false) {
+    if options.unresolved_only {
       query = query.filter(post_report::resolved.eq(false));
     }
 
@@ -186,7 +186,7 @@ pub struct PostReportQuery {
   pub community_id: Option<CommunityId>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub unresolved_only: Option<bool>,
+  pub unresolved_only: bool,
 }
 
 impl PostReportQuery {
@@ -532,7 +532,7 @@ mod tests {
     // Do a batch read of timmys reports
     // It should only show saras, which is unresolved
     let reports_after_resolve = PostReportQuery {
-      unresolved_only: (Some(true)),
+      unresolved_only: (true),
       ..Default::default()
     }
     .list(pool, &inserted_timmy)

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -63,7 +63,7 @@ type PostViewTuple = (
 sql_function!(fn coalesce(x: sql_types::Nullable<sql_types::BigInt>, y: sql_types::BigInt) -> sql_types::BigInt);
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, PostView, (PostId, Option<PersonId>, Option<bool>)>,
+  impl ReadFn<'a, PostView, (PostId, Option<PersonId>, bool)>,
   impl ListFn<'a, PostView, PostQuery<'a>>,
 > {
   let all_joins = |query: post_aggregates::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
@@ -149,43 +149,40 @@ fn queries<'a>() -> Queries<
     ),
   );
 
-  let read = move |mut conn: DbConn<'a>,
-                   (post_id, my_person_id, is_mod_or_admin): (
-    PostId,
-    Option<PersonId>,
-    Option<bool>,
-  )| async move {
-    // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+  let read =
+    move |mut conn: DbConn<'a>,
+          (post_id, my_person_id, is_mod_or_admin): (PostId, Option<PersonId>, bool)| async move {
+      // The left join below will return None in this case
+      let person_id_join = my_person_id.unwrap_or(PersonId(-1));
 
-    let mut query = all_joins(
-      post_aggregates::table
-        .filter(post_aggregates::post_id.eq(post_id))
-        .into_boxed(),
-      my_person_id,
-    )
-    .select(selection);
+      let mut query = all_joins(
+        post_aggregates::table
+          .filter(post_aggregates::post_id.eq(post_id))
+          .into_boxed(),
+        my_person_id,
+      )
+      .select(selection);
 
-    // Hide deleted and removed for non-admins or mods
-    if !is_mod_or_admin.unwrap_or(false) {
-      query = query
-        .filter(community::removed.eq(false))
-        .filter(post::removed.eq(false))
-        // users can see their own deleted posts
-        .filter(
-          community::deleted
-            .eq(false)
-            .or(post::creator_id.eq(person_id_join)),
-        )
-        .filter(
-          post::deleted
-            .eq(false)
-            .or(post::creator_id.eq(person_id_join)),
-        );
-    }
+      // Hide deleted and removed for non-admins or mods
+      if !is_mod_or_admin {
+        query = query
+          .filter(community::removed.eq(false))
+          .filter(post::removed.eq(false))
+          // users can see their own deleted posts
+          .filter(
+            community::deleted
+              .eq(false)
+              .or(post::creator_id.eq(person_id_join)),
+          )
+          .filter(
+            post::deleted
+              .eq(false)
+              .or(post::creator_id.eq(person_id_join)),
+          );
+      }
 
-    query.first::<PostViewTuple>(&mut conn).await
-  };
+      query.first::<PostViewTuple>(&mut conn).await
+    };
 
   let list = move |mut conn: DbConn<'a>, options: PostQuery<'a>| async move {
     let person_id = options.local_user.map(|l| l.person.id);
@@ -291,11 +288,11 @@ fn queries<'a>() -> Queries<
       query = query.filter(person::bot_account.eq(false));
     };
 
-    if options.saved_only.unwrap_or(false) {
+    if options.saved_only {
       query = query.filter(post_saved::id.is_not_null());
     }
 
-    if options.moderator_view.unwrap_or(false) {
+    if options.moderator_view {
       query = query.filter(community_moderator::person_id.is_not_null());
     }
     // Only hide the read posts, if the saved_only is false. Otherwise ppl with the hide_read
@@ -311,9 +308,9 @@ fn queries<'a>() -> Queries<
       }
     }
 
-    if options.liked_only.unwrap_or_default() {
+    if options.liked_only {
       query = query.filter(post_like::score.eq(1));
-    } else if options.disliked_only.unwrap_or_default() {
+    } else if options.disliked_only {
       query = query.filter(post_like::score.eq(-1));
     }
 
@@ -323,7 +320,7 @@ fn queries<'a>() -> Queries<
 
       // Don't show blocked communities or persons
       query = query.filter(community_block::person_id.is_null());
-      if !options.moderator_view.unwrap_or(false) {
+      if !options.moderator_view {
         query = query.filter(person_block::person_id.is_null());
       }
     }
@@ -404,7 +401,7 @@ impl PostView {
     pool: &mut DbPool<'_>,
     post_id: PostId,
     my_person_id: Option<PersonId>,
-    is_mod_or_admin: Option<bool>,
+    is_mod_or_admin: bool,
   ) -> Result<Self, Error> {
     let mut res = queries()
       .read(pool, (post_id, my_person_id, is_mod_or_admin))
@@ -429,10 +426,10 @@ pub struct PostQuery<'a> {
   pub local_user: Option<&'a LocalUserView>,
   pub search_term: Option<String>,
   pub url_search: Option<String>,
-  pub saved_only: Option<bool>,
-  pub liked_only: Option<bool>,
-  pub disliked_only: Option<bool>,
-  pub moderator_view: Option<bool>,
+  pub saved_only: bool,
+  pub liked_only: bool,
+  pub disliked_only: bool,
+  pub moderator_view: bool,
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -632,7 +629,7 @@ mod tests {
       pool,
       data.inserted_post.id,
       Some(data.local_user_view.person.id),
-      None,
+      false,
     )
     .await
     .unwrap();
@@ -691,7 +688,7 @@ mod tests {
     .unwrap();
 
     let read_post_listing_single_no_person =
-      PostView::read(pool, data.inserted_post.id, None, None)
+      PostView::read(pool, data.inserted_post.id, None, false)
         .await
         .unwrap();
 
@@ -771,7 +768,7 @@ mod tests {
       pool,
       data.inserted_post.id,
       Some(data.local_user_view.person.id),
-      None,
+      false,
     )
     .await
     .unwrap();
@@ -808,7 +805,7 @@ mod tests {
     let read_liked_post_listing = PostQuery {
       community_id: (Some(data.inserted_community.id)),
       local_user: (Some(&data.local_user_view)),
-      liked_only: (Some(true)),
+      liked_only: (true),
       ..Default::default()
     }
     .list(pool)
@@ -819,7 +816,7 @@ mod tests {
     let read_disliked_post_listing = PostQuery {
       community_id: (Some(data.inserted_community.id)),
       local_user: (Some(&data.local_user_view)),
-      disliked_only: (Some(true)),
+      disliked_only: (true),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -63,7 +63,7 @@ fn queries<'a>() -> Queries<
   let list = move |mut conn: DbConn<'a>, options: PrivateMessageReportQuery| async move {
     let mut query = all_joins(private_message_report::table.into_boxed());
 
-    if options.unresolved_only.unwrap_or(false) {
+    if options.unresolved_only {
       query = query.filter(private_message_report::resolved.eq(false));
     }
 
@@ -110,7 +110,7 @@ impl PrivateMessageReportView {
 pub struct PrivateMessageReportQuery {
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub unresolved_only: Option<bool>,
+  pub unresolved_only: bool,
 }
 
 impl PrivateMessageReportQuery {
@@ -217,7 +217,7 @@ mod tests {
       .unwrap();
 
     let reports = PrivateMessageReportQuery {
-      unresolved_only: (Some(false)),
+      unresolved_only: (false),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -52,7 +52,7 @@ fn queries<'a>() -> Queries<
     let mut query = all_joins(private_message::table.into_boxed()).select(selection);
 
     // If its unread, I only want the ones to me
-    if options.unread_only.unwrap_or(false) {
+    if options.unread_only {
       query = query.filter(private_message::read.eq(false));
       if let Some(i) = options.creator_id {
         query = query.filter(private_message::creator_id.eq(i))
@@ -121,7 +121,7 @@ impl PrivateMessageView {
 
 #[derive(Default)]
 pub struct PrivateMessageQuery {
-  pub unread_only: Option<bool>,
+  pub unread_only: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub creator_id: Option<PersonId>,
@@ -238,7 +238,7 @@ mod tests {
       .unwrap();
 
     let timmy_messages = PrivateMessageQuery {
-      unread_only: Some(false),
+      unread_only: false,
       creator_id: Option::None,
       ..Default::default()
     }
@@ -255,7 +255,7 @@ mod tests {
     assert_eq!(timmy_messages[2].recipient.id, timmy.id);
 
     let timmy_unread_messages = PrivateMessageQuery {
-      unread_only: Some(true),
+      unread_only: true,
       creator_id: Option::None,
       ..Default::default()
     }
@@ -270,7 +270,7 @@ mod tests {
     assert_eq!(timmy_unread_messages[1].recipient.id, timmy.id);
 
     let timmy_sara_messages = PrivateMessageQuery {
-      unread_only: Some(false),
+      unread_only: false,
       creator_id: Some(sara.id),
       ..Default::default()
     }
@@ -285,7 +285,7 @@ mod tests {
     assert_eq!(timmy_sara_messages[1].recipient.id, timmy.id);
 
     let timmy_sara_unread_messages = PrivateMessageQuery {
-      unread_only: Some(true),
+      unread_only: true,
       creator_id: Some(sara.id),
       ..Default::default()
     }

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -58,11 +58,11 @@ fn queries<'a>() -> Queries<
   let list = move |mut conn: DbConn<'a>, options: RegistrationApplicationQuery| async move {
     let mut query = all_joins(registration_application::table.into_boxed());
 
-    if options.unread_only.unwrap_or(false) {
+    if options.unread_only {
       query = query.filter(registration_application::admin_id.is_null())
     }
 
-    if options.verified_email_only.unwrap_or(false) {
+    if options.verified_email_only {
       query = query.filter(local_user::email_verified.eq(true))
     }
 
@@ -120,8 +120,8 @@ impl RegistrationApplicationView {
 
 #[derive(Default)]
 pub struct RegistrationApplicationQuery {
-  pub unread_only: Option<bool>,
-  pub verified_email_only: Option<bool>,
+  pub unread_only: bool,
+  pub verified_email_only: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
 }
@@ -321,7 +321,7 @@ mod tests {
 
     // Do a batch read of the applications
     let apps = RegistrationApplicationQuery {
-      unread_only: (Some(true)),
+      unread_only: (true),
       ..Default::default()
     }
     .list(pool)
@@ -398,7 +398,7 @@ mod tests {
     // Do a batch read of apps again
     // It should show only jessicas which is unresolved
     let apps_after_resolve = RegistrationApplicationQuery {
-      unread_only: (Some(true)),
+      unread_only: (true),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views_actor/src/comment_reply_view.rs
+++ b/crates/db_views_actor/src/comment_reply_view.rs
@@ -138,11 +138,11 @@ fn queries<'a>() -> Queries<
       query = query.filter(comment_reply::recipient_id.eq(recipient_id));
     }
 
-    if options.unread_only.unwrap_or(false) {
+    if options.unread_only {
       query = query.filter(comment_reply::read.eq(false));
     }
 
-    if !options.show_bot_accounts.unwrap_or(true) {
+    if !options.show_bot_accounts {
       query = query.filter(person::bot_account.eq(false));
     };
 
@@ -203,8 +203,8 @@ pub struct CommentReplyQuery {
   pub my_person_id: Option<PersonId>,
   pub recipient_id: Option<PersonId>,
   pub sort: Option<CommentSortType>,
-  pub unread_only: Option<bool>,
-  pub show_bot_accounts: Option<bool>,
+  pub unread_only: bool,
+  pub show_bot_accounts: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
 }

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -28,7 +28,7 @@ use lemmy_db_schema::{
 type CommunityViewTuple = (Community, CommunityAggregates, SubscribedType, bool);
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommunityView, (CommunityId, Option<PersonId>, Option<bool>)>,
+  impl ReadFn<'a, CommunityView, (CommunityId, Option<PersonId>, bool)>,
   impl ListFn<'a, CommunityView, CommunityQuery<'a>>,
 > {
   let all_joins = |query: community::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
@@ -68,7 +68,7 @@ fn queries<'a>() -> Queries<
                    (community_id, my_person_id, is_mod_or_admin): (
     CommunityId,
     Option<PersonId>,
-    Option<bool>,
+    bool,
   )| async move {
     let mut query = all_joins(
       community::table.find(community_id).into_boxed(),
@@ -77,7 +77,7 @@ fn queries<'a>() -> Queries<
     .select(selection);
 
     // Hide deleted and removed for non-admins or mods
-    if !is_mod_or_admin.unwrap_or(false) {
+    if !is_mod_or_admin {
       query = query.filter(not_removed_or_deleted);
     }
 
@@ -104,7 +104,7 @@ fn queries<'a>() -> Queries<
     }
 
     // Hide deleted and removed for non-admins or mods
-    if !options.is_mod_or_admin.unwrap_or(false) {
+    if !options.is_mod_or_admin {
       query = query.filter(not_removed_or_deleted).filter(
         community::hidden
           .eq(false)
@@ -145,7 +145,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(community::nsfw.eq(false).or(local_user::show_nsfw.eq(true)));
     } else {
       // No person in request, only show nsfw communities if show_nsfw is passed into request
-      if !options.show_nsfw.unwrap_or(false) {
+      if !options.show_nsfw {
         query = query.filter(community::nsfw.eq(false));
       }
     }
@@ -166,7 +166,7 @@ impl CommunityView {
     pool: &mut DbPool<'_>,
     community_id: CommunityId,
     my_person_id: Option<PersonId>,
-    is_mod_or_admin: Option<bool>,
+    is_mod_or_admin: bool,
   ) -> Result<Self, Error> {
     queries()
       .read(pool, (community_id, my_person_id, is_mod_or_admin))
@@ -194,8 +194,8 @@ pub struct CommunityQuery<'a> {
   pub sort: Option<SortType>,
   pub local_user: Option<&'a LocalUser>,
   pub search_term: Option<String>,
-  pub is_mod_or_admin: Option<bool>,
-  pub show_nsfw: Option<bool>,
+  pub is_mod_or_admin: bool,
+  pub show_nsfw: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
 }

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -154,11 +154,11 @@ fn queries<'a>() -> Queries<
       query = query.filter(person_mention::recipient_id.eq(recipient_id));
     }
 
-    if options.unread_only.unwrap_or(false) {
+    if options.unread_only {
       query = query.filter(person_mention::read.eq(false));
     }
 
-    if !options.show_bot_accounts.unwrap_or(true) {
+    if !options.show_bot_accounts {
       query = query.filter(person::bot_account.eq(false));
     };
 
@@ -220,8 +220,8 @@ pub struct PersonMentionQuery {
   pub my_person_id: Option<PersonId>,
   pub recipient_id: Option<PersonId>,
   pub sort: Option<CommentSortType>,
-  pub unread_only: Option<bool>,
-  pub show_bot_accounts: Option<bool>,
+  pub unread_only: bool,
+  pub show_bot_accounts: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
 }

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -373,7 +373,7 @@ async fn get_feed_inbox(
   let replies = CommentReplyQuery {
     recipient_id: (Some(person_id)),
     my_person_id: (Some(person_id)),
-    show_bot_accounts: (Some(show_bot_accounts)),
+    show_bot_accounts: (show_bot_accounts),
     sort: (Some(sort)),
     limit: (Some(RSS_FETCH_LIMIT)),
     ..Default::default()
@@ -384,7 +384,7 @@ async fn get_feed_inbox(
   let mentions = PersonMentionQuery {
     recipient_id: (Some(person_id)),
     my_person_id: (Some(person_id)),
-    show_bot_accounts: (Some(show_bot_accounts)),
+    show_bot_accounts: (show_bot_accounts),
     sort: (Some(sort)),
     limit: (Some(RSS_FETCH_LIMIT)),
     ..Default::default()

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -142,7 +142,7 @@ pub enum LemmyErrorType {
   InvalidQuery,
   ObjectNotLocal,
   PostIsLocked,
-  PersonIsBannedFromSite,
+  PersonIsBannedFromSite(String),
   InvalidVoteValue,
   PageDoesNotSpecifyCreator,
   PageDoesNotSpecifyGroup,

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -364,6 +364,7 @@ fn update_instance_software(conn: &mut PgConnection, user_agent: &str) -> LemmyR
   let client = Client::builder()
     .user_agent(user_agent)
     .timeout(REQWEST_TIMEOUT)
+    .connect_timeout(REQWEST_TIMEOUT)
     .build()?;
 
   let instances = instance::table.get_results::<Instance>(conn)?;


### PR DESCRIPTION
The `update_instance_software` method is missing a connect phase timeout and may run infinitely blocking all scheduled tasks if it encounters an instance it cannot connect to.

This adds the connect timeout to the scheduled task, fixing the issue.